### PR TITLE
feat(profile): display version number from .env in profile menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "prettier": "^3.6.2",
         "ts-node": "^10.9.2",
         "tw-animate-css": "^1.3.5",
         "typescript": "~5.9.2",
@@ -7556,6 +7557,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "prettier": "^3.6.2",
     "ts-node": "^10.9.2",
     "tw-animate-css": "^1.3.5",
     "typescript": "~5.9.2",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -72,6 +72,7 @@
     "register": "Register",
     "username": "Username",
     "password": "Password",
+    "version" : "Version",
     "confirmPassword": "Confirm Password",
     "back": "Back",
     "email": "Email",

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, VariantProps } from "class-variance-authority"
+import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"

--- a/src/ui/User/UserProfile.tsx
+++ b/src/ui/User/UserProfile.tsx
@@ -8,10 +8,12 @@ import {Tabs, TabsContent, TabsList, TabsTrigger} from "@/components/ui/tabs.tsx
 import {User, Shield, Key, AlertCircle} from "lucide-react";
 import {TOTPSetup} from "@/ui/User/TOTPSetup.tsx";
 import {getUserInfo} from "@/ui/main-axios.ts";
+import { getVersionInfo } from "@/ui/main-axios.ts";
 import {toast} from "sonner";
 import {PasswordReset} from "@/ui/User/PasswordReset.tsx";
 import {useTranslation} from "react-i18next";
 import {LanguageSwitcher} from "@/components/LanguageSwitcher";
+
 
 interface UserProfileProps {
     isTopbarOpen?: boolean;
@@ -27,10 +29,22 @@ export function UserProfile({isTopbarOpen = true}: UserProfileProps) {
     } | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [versionInfo, setVersionInfo] = useState<{ version: string } | null>(null);
+
 
     useEffect(() => {
         fetchUserInfo();
+        fetchVersion();
     }, []);
+
+    const fetchVersion = async () => {
+            try {
+                const info = await getVersionInfo();
+                setVersionInfo({ version: info.version });
+            } catch (err) {
+                console.error("Failed to load version info", err);
+                          }
+    };
 
     const fetchUserInfo = async () => {
         setLoading(true);
@@ -146,6 +160,13 @@ export function UserProfile({isTopbarOpen = true}: UserProfileProps) {
                                         )}
                                     </p>
                                 </div>
+                               <div>
+                                <Label>{t('common.version')}</Label>
+                                <p className="text-lg font-medium mt-1">
+                                    {versionInfo?.version || t('common.loading')}
+                                </p>
+                                </div>
+
                             </div>
                             
                             <div className="mt-6 pt-6 border-t">

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -140,6 +140,7 @@ interface AuthResponse {
 }
 
 interface UserInfo {
+    totp_enabled: boolean;
     id: string;
     username: string;
     is_admin: boolean;


### PR DESCRIPTION
### Summary
- Read version number from `.env`
- Display version number in profile menu (as mentioned in release 0.2.1 changelog)

### Motivation
The changelog referenced showing the version number in the profile, but it wasn’t implemented.
This PR adds that functionality.
#175
<img width="1641" height="683" alt="Screenshot 2025-09-05 163558" src="https://github.com/user-attachments/assets/25605644-4066-4880-b132-2433c3bde049" />



### Testing
- Tested locally with `.env` containing VERSION=1.5.0
- Verified the version shows correctly in the profile menu

Closes #175
