### PR TITLE
Handle Symlink in the File manager.

### DIFF
--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -969,6 +969,20 @@ export async function listSSHFiles(
   }
 }
 
+export async function identifySSHSymlink(
+  sessionId: string,
+  path: string,
+): Promise<{ path: string; target: string; type: "directory" | "file" }> {
+  try {
+    const response = await fileManagerApi.get("/ssh/identifySymlink", {
+      params: { sessionId, path },
+    });
+    return response.data;
+  } catch (error) {
+    handleApiError(error, "identify SSH symlink");
+  }
+}
+
 export async function readSSHFile(
   sessionId: string,
   path: string,


### PR DESCRIPTION
Fix handling of symlink when displayed in the File manager (#214 )

It identifies the type of target of symlink which is either file or directory and then accordingly moves ahead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * SSH File Manager now resolves symlinks: clicking a link opens its target (navigates to directories or opens files).
  * Symlinks are visually distinguished with a dedicated icon and are labeled “Link” in rename dialogs.
  * Added clear error toasts when resolving symlinks or reconnecting SSH sessions fails, with automatic reconnect attempts where possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->