### PR TITLE
Fix: SSH credential public key decryption across browser sessions

### DIFF
--- a/src/backend/utils/field-crypto.ts
+++ b/src/backend/utils/field-crypto.ts
@@ -17,18 +17,31 @@ class FieldCrypto {
   private static readonly ENCRYPTED_FIELDS = {
     users: new Set([
       "password_hash",
+      "passwordHash",
       "client_secret",
+      "clientSecret",
       "totp_secret",
+      "totpSecret",
       "totp_backup_codes",
+      "totpBackupCodes",
       "oidc_identifier",
+      "oidcIdentifier",
     ]),
-    ssh_data: new Set(["password", "key", "key_password"]),
+    ssh_data: new Set([
+      "password",
+      "key",
+      "key_password",
+      "keyPassword",
+    ]),
     ssh_credentials: new Set([
       "password",
       "private_key",
+      "privateKey",
       "key_password",
+      "keyPassword",
       "key",
       "public_key",
+      "publicKey",
     ]),
   };
 

--- a/src/backend/utils/lazy-field-encryption.ts
+++ b/src/backend/utils/lazy-field-encryption.ts
@@ -6,6 +6,10 @@ export class LazyFieldEncryption {
     key_password: "keyPassword",
     private_key: "privateKey",
     public_key: "publicKey",
+    // Reverse mappings for Drizzle ORM (camelCase -> snake_case)
+    keyPassword: "key_password",
+    privateKey: "private_key",
+    publicKey: "public_key",
   };
 
   static isPlaintextField(value: string): boolean {


### PR DESCRIPTION
# Fix SSH Credential Public Key Decryption Issue

## 🐛 Problem Description

### User Experience Issue
When a user adds SSH credentials (with SSH key authentication) in one browser session, everything works perfectly - they can view the credentials and connect to SSH terminals without any issues. However, when the **same user logs in from a different browser**, a critical bug appears:

**What the user sees:**
- ✅ **Private Key**: Displays correctly (decrypted, readable SSH key format)
- ❌ **Public Key**: Shows as raw encrypted JSON instead of the actual public key

**Example of the broken public key display:**
```json
{"data":"ccb71dc2de47428330c8ebb7586103dc1557dc67d81f2363a892aa133f118d186fdd4f1ff725ec05e3e262604103b098...","iv":"7bfe6726abc3c7982757e96b371f0383","tag":"3c71b159baf347582a4c18295409d16f","salt":"6bfab4ced2e150a25c7532cd541b8fb133d6aef5225c48f85ae24307c7475e17","recordId":"2"}
```

See the screenshot showing the issue - the private key displays properly while the public key shows encrypted JSON.

### Impact
- **Server stats** continue to work fine (they use the private key internally)
- **SSH terminal connections fail** because the system cannot properly use the public key for authentication
- Users experience inconsistent behavior across different browser sessions
- The credential appears "broken" when accessed from a new browser, even though it works in the original browser
- Creates confusion and frustration for users who expect credentials to work consistently

### Reproduction Steps
1. Create SSH credentials with an SSH key in Browser A (e.g., Chrome)
2. Save the credentials and verify terminal connection works ✅
3. Log out from Browser A
4. Log in to the same account from Browser B (e.g., Firefox)
5. Navigate to Credentials and view the SSH credential
6. **Bug appears**: Public key shows as encrypted JSON instead of the actual key ❌
7. Attempt to open a terminal with that credential fails

## 🔍 Root Cause

The issue was a **field name mismatch** in the encryption/decryption system:

1. **Drizzle ORM** returns query results with **camelCase** property names (e.g., `publicKey`, `privateKey`, `keyPassword`) based on the schema definition in `src/backend/database/db/schema.ts`:
   ```typescript
   publicKey: text("public_key", { length: 4096 })
   privateKey: text("private_key", { length: 16384 })
   ```

2. The `ENCRYPTED_FIELDS` configuration in `src/backend/utils/field-crypto.ts` only listed **snake_case** field names (e.g., `public_key`, `private_key`, `key_password`)

3. When `DataCrypto.decryptRecord()` checked if a field should be decrypted, it looked for the camelCase property name (`publicKey`) in a Set that only contained the snake_case name (`public_key`)

4. The check failed → `shouldEncryptField()` returned `false` → field was **not decrypted** → raw encrypted JSON was returned to the frontend

### Technical Flow
```
Database (SQLite)          Drizzle ORM              Decryption Check           Result
─────────────────          ───────────              ────────────────           ──────
public_key column    →     publicKey property  →    Is "publicKey" in Set?  →  FALSE!
(encrypted JSON)           (still encrypted)        ["public_key", ...]        (skipped)
                                                                            ↓
                                                                      Raw JSON returned
```

### Why did this only affect cross-browser sessions?
The issue always existed, but wasn't immediately visible because:
- The original browser session might have had different caching behavior
- Some code paths had fallback logic checking both naming conventions
- The bug only manifested when fetching credentials fresh from the database

## ✅ Solution

Updated `src/backend/utils/field-crypto.ts` to include **both camelCase and snake_case** versions of all encrypted field names in the `ENCRYPTED_FIELDS` configuration:

**Before:**
```typescript
ssh_credentials: new Set([
  "password",
  "private_key",    // Only snake_case
  "key_password",   // Only snake_case
  "key",
  "public_key",     // Only snake_case
]),
```

**After:**
```typescript
ssh_credentials: new Set([
  "password",
  "private_key",
  "privateKey",     // ← Added camelCase version
  "key_password",
  "keyPassword",    // ← Added camelCase version
  "key",
  "public_key",
  "publicKey",      // ← Added camelCase version
]),
```

This ensures that:
- ✅ Fields are decrypted correctly when returned by Drizzle ORM queries (camelCase properties)
- ✅ Fields are decrypted correctly when returned by raw SQL queries (snake_case columns)
- ✅ Backward compatibility is maintained with existing data
- ✅ SSH credentials work consistently across all browser sessions
- ✅ Both public and private keys display properly in all scenarios

### Additional Fix in `lazy-field-encryption.ts`
Also updated the legacy field name mapping to work bidirectionally, ensuring proper fallback handling for both naming conventions.

## 🧪 Testing

### Manual Testing Steps
After this fix:
1. ✅ Create SSH credentials with a key in Browser A
2. ✅ Verify the credential displays both private and public keys correctly
3. ✅ Log in from Browser B
4. ✅ View the same credential
5. ✅ **Both private key and public key should display properly** (not as encrypted JSON)
6. ✅ Open an SSH terminal connection - should work correctly
7. ✅ Server stats should continue to function normally

### Expected Behavior
- Public key displays as proper SSH public key format (e.g., `ssh-rsa AAAAB3NzaC1...`)
- Private key displays as proper OpenSSH private key format (with BEGIN/END markers)
- No encrypted JSON visible in the UI
- Terminal connections work from any browser session

## 📝 Changed Files

- `src/backend/utils/field-crypto.ts` - Updated `ENCRYPTED_FIELDS` to include both camelCase and snake_case naming conventions
- `src/backend/utils/lazy-field-encryption.ts` - Enhanced legacy field name mapping for bidirectional support

## 🔗 Related Issues

Fixes the critical issue where SSH public keys displayed as encrypted JSON when users logged in from different browsers, preventing terminal connections from working and causing user confusion.

## 📸 Visual Evidence

The attached screenshot shows the bug - notice how the SSH Public Key field displays the encrypted JSON structure instead of the actual public key, while the SSH Private Key displays correctly.