### PR TITLE
Fix: Password Change/Reset Credential Preservation

### DIFF
--- a/src/backend/utils/auth-manager.ts
+++ b/src/backend/utils/auth-manager.ts
@@ -295,6 +295,16 @@ class AuthManager {
       newPassword,
     );
   }
+
+  async resetUserPasswordWithPreservedDEK(
+    userId: string,
+    newPassword: string,
+  ): Promise<boolean> {
+    return await this.userCrypto.resetUserPasswordWithPreservedDEK(
+      userId,
+      newPassword,
+    );
+  }
 }
 
 export { AuthManager, type AuthenticationResult, type JWTPayload };


### PR DESCRIPTION
# Fix: Password Change/Reset Credential Preservation

## 🐛 Problem

When users changed their password or reset their password (while logged in), all SSH credentials (private keys, public keys, passwords) appeared to be wiped out and became inaccessible.

## 🔍 Root Cause

The application uses a two-layer encryption system:
- **KEK (Key Encryption Key)**: Derived from user password
- **DEK (Data Encryption Key)**: Encrypts actual user credentials

**The bug:** After changing password, `logoutUser()` was called which cleared the DEK from the session memory, making all encrypted credentials inaccessible even though they weren't actually deleted.

## ✅ Solution

### Password Change Flow
- Removed the `logoutUser()` call
- Maintain active session with the same DEK
- Re-encrypt DEK with new password's KEK
- Create proper deep copy of DEK buffer before cleanup
- ✅ **User data is ALWAYS preserved**

### Password Reset Flow  
Enhanced to intelligently handle two scenarios:

**When logged in (resetting from settings):**
- Detects active session with existing DEK
- Uses new `resetUserPasswordWithPreservedDEK()` method
- Re-encrypts same DEK with new password
- ✅ **User data is preserved**

**When not logged in (forgot password):**
- No access to old DEK (security by design)
- Generates new DEK as before
- ⚠️ **Old data becomes inaccessible** (expected behavior)

## 📝 Changes

### Modified Files
- `src/backend/utils/user-crypto.ts`
  - Fixed `changeUserPassword()` to maintain session
  - Added `resetUserPasswordWithPreservedDEK()` method
  - Improved Buffer handling with proper deep copying

- `src/backend/utils/auth-manager.ts`
  - Exposed `resetUserPasswordWithPreservedDEK()` method
  - Added `isUserUnlocked()` helper

- `src/backend/database/routes/users.ts`
  - Updated `/users/change-password` route
  - Enhanced `/users/complete-reset` to detect active sessions
  - Added database save triggers

### Documentation
- `PASSWORD_CHANGE_FIX.md` - Comprehensive documentation of the fix

## 🧪 Testing

Verified that:
- [x] Password change preserves all credentials
- [x] Password reset (while logged in) preserves credentials
- [x] Password reset (forgot password) generates new DEK as expected
- [x] SSH keys remain accessible after password operations
- [x] Database persistence works correctly

## 🔒 Security Notes

- The DEK never changes during password change - only how it's encrypted
- Proper memory cleanup with Buffer.fill(0) to prevent leaks
- Session management maintains security boundaries
- Password reset without login still prevents unauthorized data access

## 📊 Impact

- **User Experience**: ✅ No more credential loss after password changes
- **Security**: ✅ Maintains encryption integrity
- **Breaking Changes**: ❌ None - backward compatible
- **Database Migration**: ❌ Not required

---

### Before
```
Change Password → Logout → DEK cleared from memory → Credentials inaccessible ❌
```

### After
```
Change Password → Session maintained → DEK stays in memory → Credentials accessible ✅
```
